### PR TITLE
optionally start cockroach cluster for tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,13 @@ go 1.12
 require (
 	github.com/ThreeDotsLabs/watermill v1.1.1
 	github.com/cockroachdb/cockroach-go v0.0.0-20190925194419-606b3d062051
-	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
 	github.com/jackc/pgx/v4 v4.4.1
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
-	github.com/kr/pty v1.1.8 // indirect
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c // indirect
-	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -46,6 +47,7 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=

--- a/pkg/crdb/main_test.go
+++ b/pkg/crdb/main_test.go
@@ -1,0 +1,24 @@
+package crdb
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/watermill-crdb/pkg/crdb/testutils"
+)
+
+var PGURL string
+
+func TestMain(m *testing.M) {
+	pgURL, cleanup, err := testutils.MaybeStartCockroachCluster()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set up cockroach: %v\n", err)
+		os.Exit(1)
+	}
+	PGURL = pgURL
+	var code int
+	defer os.Exit(code)
+	defer cleanup()
+	code = m.Run()
+}

--- a/pkg/crdb/publisher_test.go
+++ b/pkg/crdb/publisher_test.go
@@ -18,7 +18,7 @@ func TestPublishDB(t *testing.T) {
 	topic := watermill.NewUUID()
 	logger := watermill.NewStdLogger(true, testing.Verbose())
 
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)
@@ -47,7 +47,7 @@ func TestPublishTx(t *testing.T) {
 	topic := watermill.NewUUID()
 	logger := watermill.NewStdLogger(true, testing.Verbose())
 
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)

--- a/pkg/crdb/pubsub_test.go
+++ b/pkg/crdb/pubsub_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func PubSubConstructor(t *testing.T, conn *sql.DB, consumerGroup string) (message.Publisher, message.Subscriber) {
+func PubSubConstructor(
+	t *testing.T, conn *sql.DB, consumerGroup string,
+) (message.Publisher, message.Subscriber) {
 	logger := watermill.NewStdLogger(true, testing.Verbose())
 
 	publisher := crdb.NewPublisher(conn, logger)
@@ -23,7 +25,7 @@ func PubSubConstructor(t *testing.T, conn *sql.DB, consumerGroup string) (messag
 }
 
 func TestWatermillUniversal(t *testing.T) {
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(crdb.PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)

--- a/pkg/crdb/schema.go
+++ b/pkg/crdb/schema.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 )
 
-const sessionTable = `"watermill_sessions"`
 const cursorsTable = `"watermill_subscriber_cursors"`
 
 func InitializeSessionSchema(ctx context.Context, db *sql.DB) error {
@@ -22,7 +21,9 @@ func InitializeSessionSchema(ctx context.Context, db *sql.DB) error {
 	return err
 }
 
-func InitializeMessageSchema(ctx context.Context, db *sql.DB, topic string, logger watermill.LoggerAdapter) error {
+func InitializeMessageSchema(
+	ctx context.Context, db *sql.DB, topic string, logger watermill.LoggerAdapter,
+) error {
 	if err := validateTopicName(topic); err != nil {
 		return err
 	}
@@ -46,7 +47,13 @@ func InitializeMessageSchema(ctx context.Context, db *sql.DB, topic string, logg
 	return err
 }
 
-func InitializeClaimsSchema(ctx context.Context, db *sql.DB, topic string, consumerGroup string, logger watermill.LoggerAdapter) error {
+func InitializeClaimsSchema(
+	ctx context.Context,
+	db *sql.DB,
+	topic string,
+	consumerGroup string,
+	logger watermill.LoggerAdapter,
+) error {
 	query := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 		message_id UUID PRIMARY KEY NOT NULL REFERENCES %s,
 		session_id UUID NOT NULL,
@@ -62,7 +69,9 @@ func InitializeClaimsSchema(ctx context.Context, db *sql.DB, topic string, consu
 	return err
 }
 
-func InitializeCursorsSchema(ctx context.Context, db *sql.DB, logger watermill.LoggerAdapter) error {
+func InitializeCursorsSchema(
+	ctx context.Context, db *sql.DB, logger watermill.LoggerAdapter,
+) error {
 	// Enabled Changefeeds
 	if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.rangefeed.enabled = true;`); err != nil {
 		return err

--- a/pkg/crdb/session.go
+++ b/pkg/crdb/session.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const sessionTable = `"watermill_sessions"`
+
 type Session struct {
 	rw                sync.Mutex
 	closed            bool

--- a/pkg/crdb/session_test.go
+++ b/pkg/crdb/session_test.go
@@ -25,7 +25,7 @@ func TestNewSession(t *testing.T) {
 }
 
 func TestSessionRun(t *testing.T) {
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(crdb.PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)
@@ -70,7 +70,7 @@ func TestSessionRun(t *testing.T) {
 }
 
 func TestSessionsRemoveExpiredSessions(t *testing.T) {
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(crdb.PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)

--- a/pkg/crdb/subscriber.go
+++ b/pkg/crdb/subscriber.go
@@ -165,7 +165,9 @@ func (s *subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 	return out, nil
 }
 
-func (s *subscriber) setCursor(ctx context.Context, tx *sql.Tx, topic string, cursor time.Time) error {
+func (s *subscriber) setCursor(
+	ctx context.Context, tx *sql.Tx, topic string, cursor time.Time,
+) error {
 	query := fmt.Sprintf(`
 		INSERT INTO %s(topic, consumer_group, cursor)
 		VALUES ($1, $2, $3)
@@ -194,7 +196,9 @@ func (s *subscriber) cursor(ctx context.Context, tx *sql.Tx, topic string) (time
 
 // missedMessageIDs returns a slice of internal ids of all non-acked non-claimed messages
 // that should have been proccessed before cursor
-func (s *subscriber) missedMessageIDs(ctx context.Context, session *Session, tx *sql.Tx, topic string, cursor time.Time) ([]string, error) {
+func (s *subscriber) missedMessageIDs(
+	ctx context.Context, session *Session, tx *sql.Tx, topic string, cursor time.Time,
+) ([]string, error) {
 	query := fmt.Sprintf(`SELECT msg.id FROM %s msg
 		LEFT JOIN %s claim ON claim.message_id = msg.id
 		WHERE msg.consume_after <= $1
@@ -356,7 +360,9 @@ func (s *subscriber) consume(
 	return rows.Err()
 }
 
-func (s *subscriber) claimMessage(ctx context.Context, session *Session, tx *sql.Tx, topic string, messageID string) (*messageRow, error) {
+func (s *subscriber) claimMessage(
+	ctx context.Context, session *Session, tx *sql.Tx, topic string, messageID string,
+) (*messageRow, error) {
 	query := fmt.Sprintf(`SELECT msg.id, msg.published_at, msg.consume_after, msg.message_id, msg.payload, msg.meta FROM
 	%s msg
 	LEFT JOIN %s ack ON ack.message_id = msg.id
@@ -399,10 +405,7 @@ func (s *subscriber) claimMessage(ctx context.Context, session *Session, tx *sql
 }
 
 func (s *subscriber) sendMessage(
-	ctx context.Context,
-	row *messageRow,
-	out chan *message.Message,
-	logger watermill.LoggerAdapter,
+	ctx context.Context, row *messageRow, out chan *message.Message, logger watermill.LoggerAdapter,
 ) (acked bool) {
 	msg := row.Msg
 

--- a/pkg/crdb/subscriber_test.go
+++ b/pkg/crdb/subscriber_test.go
@@ -16,7 +16,7 @@ func TestSubscriberMissedMessages(t *testing.T) {
 	topic := watermill.NewUUID()
 	logger := watermill.NewStdLogger(true, testing.Verbose())
 
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)
@@ -129,7 +129,7 @@ func TestConsumeAfter(t *testing.T) {
 	topic := watermill.NewUUID()
 	logger := watermill.NewStdLogger(true, testing.Verbose())
 
-	config, err := pgx.ParseConfig("postgres://root@localhost:43430/defaultdb?sslmode=disable")
+	config, err := pgx.ParseConfig(PGURL)
 	require.NoError(t, err)
 
 	conn := stdlib.OpenDB(*config)

--- a/pkg/crdb/testutils/testutils.go
+++ b/pkg/crdb/testutils/testutils.go
@@ -1,0 +1,84 @@
+// Package testutils provides testing utilities for testing watermill-crdb.
+package testutils
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+var config = struct {
+	cockroachBinary string
+	pgURL           string
+}{}
+
+func init() {
+	flag.CommandLine.StringVar(&config.cockroachBinary, "cockroach-binary",
+		"cockroach", "binary to use for cockroach, used if pgurl is "+
+			"not provided")
+	flag.CommandLine.StringVar(&config.pgURL, "pgurl", "",
+		"if set, used for testing")
+}
+
+// MaybeStartCockroachCluster will inspect the flags and either return the
+// pgurl defined by that flag or start a cockroach cluster for testing using
+// the appropriate binary.
+func MaybeStartCockroachCluster() (pgURL string, cleanup func(), err error) {
+	flag.Parse()
+	if config.pgURL != "" {
+		return config.pgURL, noop, nil
+	}
+	cockroach, err := exec.LookPath(config.cockroachBinary)
+	if err != nil {
+		return "", nil, err
+	}
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", nil, err
+	}
+	listenURLFilePath := filepath.Join(dir, "listen-url")
+	cmd := exec.Command(cockroach,
+		"start-single-node",
+		"--insecure",
+		"--listen-addr", "0.0.0.0:0",
+		"--store=type=mem,size=10%",
+		"--listening-url-file", listenURLFilePath)
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, err
+	}
+	cleanup = func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		_ = os.RemoveAll(dir)
+	}
+	if err := waitForFile(listenURLFilePath, 10*time.Second); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	url, err := ioutil.ReadFile(listenURLFilePath)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return string(bytes.TrimSpace(url)), cleanup, nil
+}
+
+func noop() {}
+
+func waitForFile(path string, timeout time.Duration) error {
+	const wait = 100 * time.Millisecond
+	for deadline := time.Now().Add(timeout); time.Until(deadline) > 0; {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			time.Sleep(wait)
+		} else {
+			return err
+		}
+	}
+	return context.DeadlineExceeded
+}


### PR DESCRIPTION
Before this PR, the tests all assumed that there would be a cockroach cluster running at a fixed address. Now you can provide a URL using the `--pgurl` flag or you can provide a binary to use to start a single-node cluster using `--cockroach-binary`.